### PR TITLE
Correct example output

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,6 @@ Install with `npm install github-slug`
 var ghslug = require('github-slug');
 ghslug('./', function (err, slug) {
   console.log(slug);
-  // evaluates to 'finnp/node-github-slug' in this directory
+  // evaluates to 'finnp/github-slug' in this directory
 });
 ```


### PR DESCRIPTION
Outputs `finnp/github-slug` here, not `finnp/node-github-slug`.
