### PR TITLE
Remove extraneous `url` var

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,10 @@ var originUrl = require('git-remote-origin-url');
 var urlFromGit = require('github-url-from-git');
 var urlParse = require('url').parse;
 
-var url = urlFromGit(url);
 module.exports = function (path, cb) {
     originUrl(path, function (err, url) {
       if(err) return cb(err);
-      var url = urlFromGit(url);
+      url = urlFromGit(url);
       var slug = urlParse(url).path.slice(1);
       cb(null, slug);
   });


### PR DESCRIPTION
`url` is already defined in the callback arguments of `originUrl()`. No need for the `var` keyword.
