### PR TITLE
fix: pass error if remote "origin" is not a github url

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = function (path, cb) {
     originUrl(path, function (err, url) {
       if(err) return cb(err);
       url = urlFromGit(url);
+      if(typeof url !== 'string') return cb(new Error('No GitHub URL in remote "origin"'))
       var slug = urlParse(url).path.slice(1);
       cb(null, slug);
   });


### PR DESCRIPTION
Hey @finnp,

thanks for this module. As url now requires Strings being passed to it I've added this check to prevent TypeErrors from throwing.

I'm now passing an Error to the callback (I like Errors), which is a breaking change. If you want to I'll change it passing an empty string to keep backwards compat.

https://github.com/greenkeeperio/greenkeeper/issues/15#issuecomment-143765709

Best,
Stephan