### PR TITLE
Allow usage of global .gitconfig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,18 @@
+sudo: false
 language: node_js
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false
 node_js:
-  - '0.12'
-  - '4.0'
+  - '4'
+before_install:
+  - npm i -g npm@^2.0.0
+before_script:
+  - npm prune
+after_success:
+  - npm run semantic-release
+branches:
+  except:
+    - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/index.js
+++ b/index.js
@@ -1,22 +1,37 @@
 var urlFromGit = require('github-url-from-git')
 var gitconfiglocal = require('gitconfiglocal')
 var urlParse = require('url').parse
+var resolvePath = require('path').resolve
+var exec = require('child_process').execFile
 
 module.exports = function (path, remote, cb) {
+  path = resolvePath(path)
   if (typeof remote === 'function') {
     cb = remote
     remote = 'origin'
   }
 
-  gitconfiglocal(path, function (err, config) {
-    if (err) return cb(err)
-    if ('remote' in config && remote in config.remote && 'url' in config.remote[remote]) {
-      var url = urlFromGit(config.remote[remote].url)
-      if (!url) return cb(new Error('Not a GitHub URL'))
-      var slug = urlParse(url).path.slice(1)
-      cb(null, slug)
-    } else {
-      cb(new Error('No GitHub URL in remote "' + remote + '"'))
+  var gitArgs = ['remote', 'show', '-n', remote]
+  var matchFetch = /Fetch URL: (.+)/
+
+  exec('git', gitArgs, {cwd: path}, function (err, stdout) {
+    if (!err && stdout) {
+      var match = matchFetch.exec(stdout.toString())
+      if (match) return parseUrl(match[1].trim())
     }
+    // fall back to parsing .git/config
+    gitconfiglocal(path, function (err, config) {
+      if (err) return cb(err)
+      var hasRemoteUrl = 'remote' in config && remote in config.remote && 'url' in config.remote[remote]
+      if (hasRemoteUrl) return parseUrl(config.remote[remote].url)
+      cb(new Error('No GitHub URL in remote "' + remote + '"'))
+    })
   })
+
+  function parseUrl (gitUrl) {
+    var remoteUrl = urlFromGit(gitUrl)
+    if (!remoteUrl) return cb(new Error('Not a GitHub URL'))
+    var slug = urlParse(remoteUrl).path.slice(1)
+    cb(null, slug)
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "github-slug",
-  "version": "1.1.0",
   "description": "Get the github slug (username/repo) of the current folder",
   "main": "index.js",
   "scripts": {
-    "test": "node test/test.js"
+    "test": "node test/test.js",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "author": "Finn Pauls",
   "license": "MIT",
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "temp": "^0.8.3",
-    "tape": "^4.2.2"
+    "tape": "^4.2.2",
+    "semantic-release": "^4.3.5"
   }
 }

--- a/test/.gitconfig
+++ b/test/.gitconfig
@@ -1,0 +1,3 @@
+# URL shorthands
+[url "git@github.com:"]
+    insteadOf = "gh:"

--- a/test/test.js
+++ b/test/test.js
@@ -37,6 +37,18 @@ test('github-slug', function (t) {
     })
   })
 
+  t.test('works with global .gitconfig', function (t) {
+    process.chdir(temp.mkdirSync())
+    exec('git init')
+    exec('git remote add munter gh:greenkeeper/munter')
+    process.env.HOME = __dirname // location of .gitconfig
+    ghslug('./', 'munter', function (err, slug) {
+      t.notOk(err)
+      t.equal(slug, 'greenkeeper/munter')
+      t.end()
+    })
+  })
+
   t.test('fails if the specified remote does not exist', function (t) {
     process.chdir(temp.mkdirSync())
     exec('git init')
@@ -65,6 +77,19 @@ test('github-slug', function (t) {
     ghslug('./', function (err, slug) {
       t.ok(err)
       t.notOk(slug)
+      t.end()
+    })
+  })
+
+  t.test('returns the correct slug from .git/config when git command is not available', function (t) {
+    process.chdir(temp.mkdirSync())
+    exec('git init')
+    exec('git remote add origin https://github.com/marco-c/github-slug.git')
+    process.env.PATH = ''
+
+    ghslug('./', function (err, slug) {
+      t.notOk(err)
+      t.equal(slug, 'marco-c/github-slug')
       t.end()
     })
   })


### PR DESCRIPTION
This solves #7. It spawns `git remote show -n origin` and parses its output, falling back to parsing `.git/config` in case the `git` command fails.
